### PR TITLE
Change the hexworld link to diamond and red/blue

### DIFF
--- a/src/shared/app/hexworld.ts
+++ b/src/shared/app/hexworld.ts
@@ -14,6 +14,6 @@ export const gameToHexworldLink = (game: Game): string => game
 
             return link + move.toString();
         },
-        `https://hexworld.org/board/#${game.getSize()},`,
+        `https://hexworld.org/board/#${game.getSize()}r9c1,`,
     )
 ;


### PR DESCRIPTION
to match the default settings of the client. In the future it would be
best to match the rotation to the to user's rotation setting, but I
don't have the vue knowledge to do that right now.

I noticed there are other hexworld links in this codebase, they may need to be changed as well. I'm not sure.
