### PR TITLE
Center the counter in the header

### DIFF
--- a/src/client/vue/components/layout/AppHeader.vue
+++ b/src/client/vue/components/layout/AppHeader.vue
@@ -88,19 +88,17 @@ nav
 .my-turn-notif
     position relative
     font-size 1.7em
-    margin-top -1.5em
     width 2em
+    display flex
+    justify-content center
+    align-items center
 
     svg, a
         position absolute
         text-align center
         width 100%
 
-    svg
-        margin-top 0.22em
-
     a
         font-size 0.8em
-        margin 0.18em -0.02em
         text-decoration none
 </style>


### PR DESCRIPTION
Before
![image](https://github.com/alcalyn/hex/assets/10106819/0a867a54-3e01-49ee-b9ea-d7e378436e0c)

After
![image](https://github.com/alcalyn/hex/assets/10106819/7e99dc0a-53a9-4f11-81ad-7103e21a8709)

I tested this on Chrome, Firefox, Safari.