### PR TITLE
Change "Rematch" -> "New Game"

### DIFF
--- a/src/client/vue/components/overlay/GameFinishedOverlay.vue
+++ b/src/client/vue/components/overlay/GameFinishedOverlay.vue
@@ -81,7 +81,7 @@ const downloadSGF = (): void => {
                             type="button"
                             class="btn btn-primary"
                             @click="confirm(); rematch();"
-                        ><BIconRepeat /> Rematch</button>
+                        ><BIconRepeat /> New Game</button>
 
                         <button
                             type="button"


### PR DESCRIPTION
Right now "Rematch" is misleading. People expect that if they both hit
rematch, they will play each other again, but if they do that, they will
just be waiting in their own lobbies, and might even come to the
conclusion that the other person doesn't want to play anymore.
