### PR TITLE
Update title reactively

### DIFF
--- a/src/client/services/head.ts
+++ b/src/client/services/head.ts
@@ -20,7 +20,8 @@ export const useHeadDefault = (): void => {
     useSeoMeta({
         robots: 'index',
 
-        title: seo.title,
+        titleTemplate: (title?: string) =>
+            title ? `${title} - ${seo.title}` : seo.title,
         description: seo.description,
 
         ogType: 'website',

--- a/src/client/vue/pages/PageLobby.vue
+++ b/src/client/vue/pages/PageLobby.vue
@@ -24,7 +24,7 @@ import i18next from 'i18next';
 import { createGameOptionsFromUrlHash } from '../../services/create-game-options-from-url-hash';
 
 const updateSeoMeta = () => useSeoMeta({
-    titleTemplate: title => `${i18next.t('lobby_title')} - ${title}`,
+    title: i18next.t('lobby_title'),
 });
 
 updateSeoMeta();

--- a/src/client/vue/pages/PagePlayRemote.vue
+++ b/src/client/vue/pages/PagePlayRemote.vue
@@ -273,7 +273,7 @@ const loadGame = async () => {
 
     useSeoMeta({
         robots: 'noindex',
-        titleTemplate: site => `${title} - ${site}`,
+        title,
         ogTitle: title,
         description,
         ogDescription: description,

--- a/src/client/vue/pages/PagePlayRemote.vue
+++ b/src/client/vue/pages/PagePlayRemote.vue
@@ -2,7 +2,7 @@
 /* eslint-env browser */
 import GameView from '@client/pixi-board/GameView';
 import useLobbyStore from '@client/stores/lobbyStore';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import AppBoard from '@client/vue/components/AppBoard.vue';
 import ConfirmationOverlay from '@client/vue/components/overlay/ConfirmationOverlay.vue';
 import HostedGameClient from '../../HostedGameClient';
@@ -17,10 +17,12 @@ import { BIconFlag, BIconXLg, BIconCheck, BIconChatRightText, BIconChatRight, BI
 import usePlayerSettingsStore from '../../stores/playerSettingsStore';
 import usePlayerLocalSettingsStore from '../../stores/playerLocalSettingsStore';
 import { storeToRefs } from 'pinia';
+import i18next from 'i18next';
 import { PlayerIndex } from '@shared/game-engine';
 import { useSeoMeta } from '@unhead/vue';
 import AppGameSidebar from '../components/AppGameSidebar.vue';
 import { fromEngineMove } from '../../../shared/app/models/Move';
+import { pseudoString } from '../../../shared/app/pseudoUtils';
 
 useSeoMeta({
     robots: 'noindex',
@@ -28,7 +30,7 @@ useSeoMeta({
 
 const { gameId } = useRoute().params;
 
-const hostedGameClient = ref<null | HostedGameClient>(null);
+const hostedGameClient: Ref<HostedGameClient | null> = ref(null);
 
 const boardContainer = ref<HTMLElement>();
 let gameView: null | GameView = null; // Cannot be a ref() because crash when toggle coords and hover board
@@ -245,6 +247,24 @@ const initGameView = async () => {
     }
 };
 
+const makeTitle = (gameClient: HostedGameClient) => {
+    const players = gameClient.getPlayers();
+    const { state } = gameClient.getHostedGame();
+    const playerPseudos = players.map(p => pseudoString(p, 'pseudo'));
+    if (players.length < 2 && 'created' === state)
+        return `${i18next.t('game.title_waiting')} ${playerPseudos[0]}`;
+    let yourTurn = '';
+    if ('playing' === state && loggedInPlayer.value != null) {
+        const player = loggedInPlayer.value;
+        const index = players.findIndex(p => p.publicId === player.publicId);
+        if (index != null && gameClient.getGame().getCurrentPlayerIndex() === index) {
+            yourTurn = `• ${i18next.t('game.title_your_turn')} • `;
+        }
+    }
+    const pairing = playerPseudos.join(' VS ');
+    return `${yourTurn}${i18next.t('game_state.' + state)}: ${pairing}`;
+};
+
 /*
  * Load game
  */
@@ -262,19 +282,17 @@ const loadGame = async () => {
 
     const playerPseudos = hostedGameClient.value.getPlayers().map(p => p.pseudo);
     const { state, host } = hostedGameClient.value.getHostedGame();
-    const stateForTitle = playerPseudos.length < 2 && 'created' === state
-        ? 'Waiting for an opponent'
-        : state[0].toUpperCase() + state.slice(1);
-    const title = `${stateForTitle}: ${playerPseudos.join(' VS ')}`;
     const description = 'created' === state
         ? `Hex game, hosted by ${host.pseudo}, waiting for an opponent.`
-        : `${state} Hex game, ${playerPseudos.join(' versus ')}.`
+        : `Hex game, ${playerPseudos.join(' versus ')}.`
     ;
 
     useSeoMeta({
         robots: 'noindex',
-        title,
-        ogTitle: title,
+        title: computed(() => {
+            if (hostedGameClient.value == null) return '';
+            return makeTitle(hostedGameClient.value);
+        }),
         description,
         ogDescription: description,
     });

--- a/src/client/vue/pages/content/PageAnalysisDetails.vue
+++ b/src/client/vue/pages/content/PageAnalysisDetails.vue
@@ -3,7 +3,7 @@ import { useSeoMeta } from '@unhead/vue';
 import { BIconInfoCircleFill } from 'bootstrap-icons-vue';
 
 useSeoMeta({
-    titleTemplate: title => `Hex game analysis - ${title}`,
+    title: 'Hex game analysis',
 });
 </script>
 

--- a/src/client/vue/pages/content/PageContribute.vue
+++ b/src/client/vue/pages/content/PageContribute.vue
@@ -3,7 +3,7 @@ import { useSeoMeta } from '@unhead/vue';
 import { ref } from 'vue';
 
 useSeoMeta({
-    titleTemplate: title => `How to contribute - ${title}`,
+    title: 'How to contribute',
 });
 
 const playerIsFair = ref(0);

--- a/src/client/vue/pages/content/PageContributors.vue
+++ b/src/client/vue/pages/content/PageContributors.vue
@@ -5,7 +5,7 @@ import type { PlayHexContributors } from '../../../../shared/app/Types';
 import { ref } from 'vue';
 
 useSeoMeta({
-    titleTemplate: title => `Contributors - ${title}`,
+    title: 'Contributors',
 });
 
 const contributors = ref<null | PlayHexContributors>(null);

--- a/src/client/vue/pages/content/PageHexLinks.vue
+++ b/src/client/vue/pages/content/PageHexLinks.vue
@@ -35,7 +35,7 @@ import { Component as ComponentType } from 'vue';
 import { useSeoMeta } from '@unhead/vue';
 
 useSeoMeta({
-    titleTemplate: title => `Useful Hex links - ${title}`,
+    title: 'Useful Hex links',
 });
 
 type Icon = { icon: ComponentType };

--- a/src/client/vue/pages/content/PageLicense.vue
+++ b/src/client/vue/pages/content/PageLicense.vue
@@ -2,7 +2,7 @@
 import { useSeoMeta } from '@unhead/vue';
 
 useSeoMeta({
-    titleTemplate: title => `License - ${title}`,
+    title: 'License',
 });
 </script>
 

--- a/src/client/vue/pages/content/PagePrivacyPolicy.vue
+++ b/src/client/vue/pages/content/PagePrivacyPolicy.vue
@@ -2,7 +2,7 @@
 import { useSeoMeta } from '@unhead/vue';
 
 useSeoMeta({
-    titleTemplate: title => `Privacy policy - ${title}`,
+    title: 'Privacy policy',
 });
 </script>
 

--- a/src/client/vue/pages/content/PageSpawnWorker.vue
+++ b/src/client/vue/pages/content/PageSpawnWorker.vue
@@ -2,7 +2,7 @@
 import { useSeoMeta } from '@unhead/vue';
 
 useSeoMeta({
-    titleTemplate: title => `Spawn a Hex AI worker - ${title}`,
+    title: 'Spawn a Hex AI worker',
 });
 </script>
 

--- a/src/client/vue/pages/player/PageLogin.vue
+++ b/src/client/vue/pages/player/PageLogin.vue
@@ -7,7 +7,7 @@ import { InputValidation, toInputClass } from '../../../vue/formUtils';
 import { useSeoMeta } from '@unhead/vue';
 
 useSeoMeta({
-    titleTemplate: title => `Log in - ${title}`,
+    title: 'Log in',
     description: 'Log in to your PlayHex account.',
 });
 

--- a/src/client/vue/pages/player/PagePlayer.vue
+++ b/src/client/vue/pages/player/PagePlayer.vue
@@ -34,7 +34,7 @@ if (Array.isArray(slug)) {
  */
 const updateMeta = (player: Player): void => {
     useSeoMeta({
-        titleTemplate: title => `${pseudoString(player, 'pseudo')} - ${title}`,
+        title: pseudoString(player, 'pseudo'),
 
         // index only bots (Mohex) profile page.
         // Guest should never be indexed,

--- a/src/client/vue/pages/player/PageSettings.vue
+++ b/src/client/vue/pages/player/PageSettings.vue
@@ -19,7 +19,7 @@ import AppBoard from '../../components/AppBoard.vue';
 
 const updateSeoMeta = () => useSeoMeta({
     robots: 'noindex',
-    titleTemplate: title => `${i18n.t('player_settings.title')} - ${title}`,
+    title: i18n.t('player_settings.title')
 });
 
 updateSeoMeta();

--- a/src/client/vue/pages/player/PageSignup.vue
+++ b/src/client/vue/pages/player/PageSignup.vue
@@ -7,7 +7,7 @@ import { InputValidation, toInputClass } from '../../../vue/formUtils';
 import { useSeoMeta } from '@unhead/vue';
 
 useSeoMeta({
-    titleTemplate: title => `Sign up - ${title}`,
+    title: 'Sign up',
     description: 'Create an account to keep the history of Hex games you played.',
 });
 

--- a/src/shared/app/i18n/locales/en.json
+++ b/src/shared/app/i18n/locales/en.json
@@ -26,13 +26,21 @@
         "outcome": "Outcome",
         "lost": "Lost",
         "playing": "Playing",
-        "watch": "Watch"
+        "watch": "Watch",
+        "title_your_turn": "Your turn!",
+        "title_waiting": "Waiting for an opponent: hosted by"
     },
     "game_rules": {
         "normal": "normal",
         "host_plays_first": "host plays first",
         "host_plays_second": "host plays second",
         "no_swap": "no swap"
+    },
+    "game_state": {
+        "created": "Created",
+        "canceled": "Canceled",
+        "playing": "Playing",
+        "ended": "Ended"
     },
     "create_game": {
         "custom_size": "Custom",


### PR DESCRIPTION
This also changes all pages, in a separate commit, to use `title` instead of `titleTemplate` and the default to use `titleTemplate` instead of `title` because (I think, based on types) computed + titleTemplate function don't work together in unhead, and setting one `titleTemplate` seems to be a better use of unhead anyway.