### PR TITLE
Send state updates on room joins and hence websocket (re)connects

### DIFF
--- a/src/client/HostedGameClient.ts
+++ b/src/client/HostedGameClient.ts
@@ -40,7 +40,7 @@ export default class HostedGameClient extends TypedEmitter<HostedGameClientEvent
 
     private richChat: RichChat;
 
-    private lowTimeNotificationThread: null | NodeJS.Timeout = null;
+    private lowTimeNotificationThread: null | number = null;
 
     constructor(
         private hostedGame: HostedGame,
@@ -218,6 +218,11 @@ export default class HostedGameClient extends TypedEmitter<HostedGameClientEvent
             return this.loadGame();
         }
 
+        return this.game;
+    }
+
+    getGameIfExists(): Game | null
+    {
         return this.game;
     }
 

--- a/src/client/stores/socketStore.ts
+++ b/src/client/stores/socketStore.ts
@@ -11,13 +11,10 @@ const useSocketStore = defineStore('socketStore', () => {
         autoConnect: false, // connect once player is logged in at least as guest
     });
 
-    const joinRoom = (room: string) => socket.emit('room', 'join', room);
-    const leaveRoom = (room: string) => socket.emit('room', 'leave', room);
+    const joinRoom = (room: string) => socket.emit('joinRoom', room);
+    const leaveRoom = (room: string) => socket.emit('leaveRoom', room);
 
     const connected = ref(false);
-
-    // reload in order to make sure the state is up to date
-    let shouldReloadPage = false;
 
     /*
      * Reconnect socket when logged in player changed
@@ -26,21 +23,16 @@ const useSocketStore = defineStore('socketStore', () => {
         socket.disconnect().connect();
     };
 
-    watch(
-        () => useAuthStore().loggedInPlayer,
-        () => reconnectSocket(),
-    );
+    const authStore = useAuthStore();
+
+    watch(() => authStore.loggedInPlayer, reconnectSocket);
 
     socket.on('connect', () => {
         connected.value = true;
-        if (shouldReloadPage)
-            location.reload();
     });
 
-    socket.on('disconnect', reason => {
+    socket.on('disconnect', () => {
         connected.value = false;
-        if (reason !== 'io client disconnect') // if not manual disconnect
-            shouldReloadPage = true;
     });
 
     return {

--- a/src/client/vue/components/AppOnlineStatus.vue
+++ b/src/client/vue/components/AppOnlineStatus.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import Player from '../../../shared/app/models/Player';
 import useOnlinePlayersStore from '../../stores/onlinePlayersStore';
-import { PropType, toRefs } from 'vue';
+import { PropType } from 'vue';
 import { BIconCircleFill, BIconRobot } from 'bootstrap-icons-vue';
 
 const props = defineProps({
@@ -11,15 +11,15 @@ const props = defineProps({
     },
 });
 
-const { player } = toRefs(props);
+const onlinePlayersStore = useOnlinePlayersStore();
 </script>
 
 <template>
     <BIconCircleFill
-        v-if="!player.isBot"
+        v-if="!props.player.isBot"
         class="online-status-icon"
         aria-hidden="true"
-        :class="useOnlinePlayersStore().isPlayerOnline(player.publicId) ? 'text-success' : 'text-secondary'"
+        :class="onlinePlayersStore.isPlayerOnline(props.player.publicId) ? 'text-success' : 'text-secondary'"
     />
     <BIconRobot
         v-else

--- a/src/server/controllers/websocket/GameWebsocketController.ts
+++ b/src/server/controllers/websocket/GameWebsocketController.ts
@@ -23,4 +23,12 @@ export default class GameWebsocketController implements WebsocketControllerInter
             answer(await this.hostedGameRepository.playerMove(player, gameId, move));
         });
     }
+
+    async onJoinRoom(socket: HexSocket, room: string)
+    {
+        const gameId = room.match(/games\/(.+)/)?.[1];
+        if (gameId == null) return;
+        const game = await this.hostedGameRepository.getGame(gameId);
+        socket.emit('gameUpdate', gameId, game);
+    }
 }

--- a/src/server/controllers/websocket/LobbyWebsocketController.ts
+++ b/src/server/controllers/websocket/LobbyWebsocketController.ts
@@ -2,6 +2,7 @@ import HostedGameRepository from '../../repositories/HostedGameRepository';
 import { Service } from 'typedi';
 import { WebsocketControllerInterface } from '.';
 import { HexSocket } from '../../server';
+import Rooms from '../../../shared/app/Rooms';
 
 @Service()
 export default class LobbyWebsocketController implements WebsocketControllerInterface
@@ -22,5 +23,12 @@ export default class LobbyWebsocketController implements WebsocketControllerInte
 
             answer(await this.hostedGameRepository.playerJoinGame(player, gameId));
         });
+    }
+
+    async onJoinRoom(socket: HexSocket, room: string)
+    {
+        if (room !== Rooms.lobby) return;
+        const games = await this.hostedGameRepository.getLobbyGames();
+        socket.emit('lobbyUpdate', games);
     }
 }

--- a/src/server/controllers/websocket/OnlinePlayersWebsocketController.ts
+++ b/src/server/controllers/websocket/OnlinePlayersWebsocketController.ts
@@ -42,4 +42,11 @@ export default class OnlinePlayersWebsocketController implements WebsocketContro
         this.onlinePlayersService.socketHasConnected(socket);
         socket.on('disconnect', () => this.onlinePlayersService.socketHasDisconnected(socket));
     }
+
+    onJoinRoom(socket: HexSocket, room: string): void
+    {
+        if (room !== Rooms.onlinePlayers) return;
+        const onlinePlayers = this.onlinePlayersService.getOnlinePlayers();
+        socket.emit('onlinePlayersUpdate', onlinePlayers);
+    }
 }

--- a/src/server/controllers/websocket/PlayerGamesWebsocketController.ts
+++ b/src/server/controllers/websocket/PlayerGamesWebsocketController.ts
@@ -1,0 +1,27 @@
+import HostedGameRepository from '../../repositories/HostedGameRepository';
+import PlayerRepository from '../../repositories/PlayerRepository';
+import { Service } from 'typedi';
+import { WebsocketControllerInterface } from '.';
+import { HexSocket } from '../../server';
+
+@Service()
+export default class PlayerGamesWebsocketController implements WebsocketControllerInterface
+{
+    constructor(
+        private hostedGameRepository: HostedGameRepository,
+        private playerRepository: PlayerRepository,
+    ) {}
+
+    onConnection(): void {}
+
+    async onJoinRoom(socket: HexSocket, room: string)
+    {
+        const playerId = room.match(/players\/([^/]+)\/games/)?.[1];
+        if (playerId == null) return;
+        const player = await this.playerRepository.getPlayer(playerId);
+        if (player == null) return;
+        const games = this.hostedGameRepository.getPlayerActiveGames(player)
+            .map(g => g.toData());
+        socket.emit('playerGamesUpdate', games);
+    }
+}

--- a/src/server/controllers/websocket/RoomWebsocketController.ts
+++ b/src/server/controllers/websocket/RoomWebsocketController.ts
@@ -7,11 +7,12 @@ export default class RoomWebsocketController implements WebsocketControllerInter
 {
     onConnection(socket: HexSocket): void
     {
-        socket.on('room', (join, room) => {
-            socket[join](room);
+        socket.on('joinRoom', room => {
+            socket.join(room);
         });
 
-        socket.join('lobby');
-        socket.join('online-players');
+        socket.on('leaveRoom', room => {
+            socket.leave(room);
+        });
     }
 }

--- a/src/shared/app/HexSocketEvents.ts
+++ b/src/shared/app/HexSocketEvents.ts
@@ -2,6 +2,7 @@ import { Outcome } from '../game-engine/Types';
 import { PlayerIndex } from '../game-engine';
 import { GameTimeData } from 'time-control/TimeControl';
 import { ChatMessage, GameAnalyze, HostedGame, Move, Player, Rating } from './models';
+import type { OnlinePlayers } from './models';
 
 export type HexClientToServerEvents = {
     /**
@@ -11,9 +12,14 @@ export type HexClientToServerEvents = {
     joinGame: (gameId: string, answer: (joined: true | string) => void) => void;
 
     /**
-     * A player wants to join or leave a room.
+     * A player wants to join a room.
      */
-    room: (join: 'join' | 'leave', room: string) => void;
+    joinRoom: (room: string) => void;
+
+    /**
+     * A player wants to leave a room.
+     */
+    leaveRoom: (room: string) => void;
 
     /**
      * A player wants to play a move.
@@ -130,4 +136,18 @@ export type HexServerToClientEvents = {
      * to know if game analyze has finished, or is just requested.
      */
     analyze: (gameId: string, gameAnalyze: GameAnalyze) => void;
+
+    // Room updates
+
+    /** State for the `Rooms.lobby` room. */
+    lobbyUpdate: (games: HostedGame[]) => void;
+
+    /** State for the `Rooms.onlinePlayers` room. */
+    onlinePlayersUpdate: (onlinePlayers: OnlinePlayers) => void;
+
+    /** State for the `Rooms.game` room. */
+    gameUpdate: (gameId: string, game: HostedGame | null) => void;
+
+    /** State for the `Rooms.playerGames` room. */
+    playerGamesUpdate: (myGames: HostedGame[]) => void;
 };

--- a/src/shared/game-engine/Game.ts
+++ b/src/shared/game-engine/Game.ts
@@ -565,6 +565,35 @@ export default class Game extends TypedEmitter<GameEvents>
         };
     }
 
+    updateFromData(gameData: GameData) {
+        const lastMove = this.getLastMove();
+        let found = lastMove == null;
+        // Update move history only from the last move that we have (or from
+        // the beginning if lastMove is null)
+        let i = this.movesHistory.length;
+        for (const moveData of gameData.movesHistory) {
+            if (!found) {
+                if (moveData.col === lastMove!.col && moveData.row === lastMove!.row)
+                    found = true;
+                continue;
+            }
+            this.move(Move.fromData(moveData), i % 2 as PlayerIndex);
+            i++;
+        }
+
+        this.currentPlayerIndex = gameData.currentPlayerIndex;
+        this.startedAt = gameData.startedAt;
+        this.lastMoveAt = gameData.lastMoveAt;
+
+        if (this.endedAt == null && this.winner == null && gameData.endedAt != null && gameData.winner != null) {
+            this.declareWinner(gameData.winner, gameData.outcome, gameData.endedAt);
+        } else {
+            this.winner = gameData.winner;
+            this.outcome = gameData.outcome;
+            this.endedAt = gameData.endedAt;
+        }
+    }
+
     static fromData(gameData: GameData): Game
     {
         const game = new Game(gameData.size);


### PR DESCRIPTION
Fixes #79

Requires more testing.

There's a disadvantage to this that the on-event actions in a game aren't triggered (e.g. playing a sound), but this is still much better than losing state. (This issue isn't unfixable: it can be solved by more properly implementing state synchronization.)

Additional note: `socket.join('lobby'); socket.join('online-players')` are removed from `RoomWebsocketController` because it is important that socket listeners (in the stores) are set before the room is joined.